### PR TITLE
run unattended from command line

### DIFF
--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -66,6 +66,8 @@ namespace SQLQueryStress
 
         //This is the total time as reported by the client
         private double _totalTime;
+
+        private bool _autoStart;
         //Number of query requests that returned time messages
         //Note:: Average times will be computed by:
         // A) Add up all results from time messages returned by 
@@ -79,9 +81,12 @@ namespace SQLQueryStress
         //WAITFOR DELAY '00:00:05'  (1300 ms?? WTF??)
         private int _totalTimeMessages;
 
-        public Form1(string configFile) : this()
+        public Form1(string configFile, bool autoStart) : this()
         {
             OpenConfigFile(configFile);
+
+            // set the start processing after form is loaded
+            if (_autoStart = autoStart) Load += StartProcessing;
         }
 
         public Form1()
@@ -95,6 +100,11 @@ namespace SQLQueryStress
             openFileDialog1.DefaultExt = "sqlstress";
             openFileDialog1.Filter = @"SQLQueryStress Configuration Files|*.sqlstress";
             openFileDialog1.FileOk += openFileDialog1_FileOk;
+        }
+
+        private void StartProcessing(Object sender, EventArgs e)
+        {
+            go_button.PerformClick();
         }
 
         private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
@@ -185,7 +195,8 @@ namespace SQLQueryStress
 
             db_label.Text = "";
 
-            if (_exitOnComplete)
+            // if we started automatically exit when done
+            if (_exitOnComplete || _autoStart)
             {
                 Dispose();
             }

--- a/src/SQLQueryStress/LoadEngine.cs
+++ b/src/SQLQueryStress/LoadEngine.cs
@@ -480,7 +480,7 @@ namespace SQLQueryStress
                                 //Clean up the connection
                                 if (_statsComm != null && conn != null)
                                     conn.InfoMessage -= handler;
-                                conn?.Close();
+                                conn.Close();
                             }
 
                             var finished = i == _iterations - 1;

--- a/src/SQLQueryStress/Program.cs
+++ b/src/SQLQueryStress/Program.cs
@@ -17,8 +17,8 @@ namespace SQLQueryStress
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            var f = args.Length > 0 ? new Form1(args[0]) : new Form1();
-
+            bool autoStart = (args.Length > 1) ? Convert.ToBoolean(args[1]) : false;
+            var f = args.Length > 0 ? new Form1(args[0], autoStart) : new Form1();
             f.StartPosition = FormStartPosition.CenterScreen;
             Application.Run(f);
         }

--- a/src/SQLQueryStress/SqlControl.xaml.cs
+++ b/src/SQLQueryStress/SqlControl.xaml.cs
@@ -38,7 +38,7 @@ namespace SQLQueryStress
             }
             finally
             {
-                stream?.Dispose();
+                if (stream != null) stream.Dispose();
             }
         }
     }


### PR DESCRIPTION
Added ability to specify true/false in command line, in addition to
existing settings file to automatically run and exit:
>SQLQueryStress.exe "fast run.sqlstress" true
It will mimic clicking the GO button and exit after execution, so you
can run different tests unattended.
Fixed typos (strange ? symbols)  in LoadEngine and SQLControl files.