### PR TITLE
Run unattended from cmd line

### DIFF
--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -66,8 +66,6 @@ namespace SQLQueryStress
 
         //This is the total time as reported by the client
         private double _totalTime;
-
-        private bool _autoStart;
         //Number of query requests that returned time messages
         //Note:: Average times will be computed by:
         // A) Add up all results from time messages returned by 
@@ -81,12 +79,9 @@ namespace SQLQueryStress
         //WAITFOR DELAY '00:00:05'  (1300 ms?? WTF??)
         private int _totalTimeMessages;
 
-        public Form1(string configFile, bool autoStart) : this()
+        public Form1(string configFile) : this()
         {
             OpenConfigFile(configFile);
-
-            // set the start processing after form is loaded
-            if (_autoStart = autoStart) Load += StartProcessing;
         }
 
         public Form1()
@@ -100,11 +95,6 @@ namespace SQLQueryStress
             openFileDialog1.DefaultExt = "sqlstress";
             openFileDialog1.Filter = @"SQLQueryStress Configuration Files|*.sqlstress";
             openFileDialog1.FileOk += openFileDialog1_FileOk;
-        }
-
-        private void StartProcessing(Object sender, EventArgs e)
-        {
-            go_button.PerformClick();
         }
 
         private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
@@ -195,8 +185,7 @@ namespace SQLQueryStress
 
             db_label.Text = "";
 
-            // if we started automatically exit when done
-            if (_exitOnComplete || _autoStart)
+            if (_exitOnComplete)
             {
                 Dispose();
             }

--- a/src/SQLQueryStress/Form1.cs
+++ b/src/SQLQueryStress/Form1.cs
@@ -66,6 +66,8 @@ namespace SQLQueryStress
 
         //This is the total time as reported by the client
         private double _totalTime;
+
+        private bool _unattendedMode;
         //Number of query requests that returned time messages
         //Note:: Average times will be computed by:
         // A) Add up all results from time messages returned by 
@@ -79,9 +81,16 @@ namespace SQLQueryStress
         //WAITFOR DELAY '00:00:05'  (1300 ms?? WTF??)
         private int _totalTimeMessages;
 
-        public Form1(string configFile) : this()
+        public Form1(string configFile, bool unattendedMode, int numThreads) : this()
         {
-            OpenConfigFile(configFile);
+            // load config file if specified
+            if (configFile.Length > 0) OpenConfigFile(configFile);
+
+            // set the start processing after form is loaded
+            if (_unattendedMode = unattendedMode) Load += StartProcessing;
+            
+            // are we overriding the config file?
+            if (numThreads > 0) threads_numericUpDown.Value = _settings.NumThreads = numThreads;
         }
 
         public Form1()
@@ -95,6 +104,11 @@ namespace SQLQueryStress
             openFileDialog1.DefaultExt = "sqlstress";
             openFileDialog1.Filter = @"SQLQueryStress Configuration Files|*.sqlstress";
             openFileDialog1.FileOk += openFileDialog1_FileOk;
+        }
+
+        private void StartProcessing(Object sender, EventArgs e)
+        {
+            go_button.PerformClick();
         }
 
         private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
@@ -185,7 +199,8 @@ namespace SQLQueryStress
 
             db_label.Text = "";
 
-            if (_exitOnComplete)
+            // if we started automatically exit when done
+            if (_exitOnComplete || _unattendedMode)
             {
                 Dispose();
             }

--- a/src/SQLQueryStress/LoadEngine.cs
+++ b/src/SQLQueryStress/LoadEngine.cs
@@ -480,7 +480,7 @@ namespace SQLQueryStress
                                 //Clean up the connection
                                 if (_statsComm != null && conn != null)
                                     conn.InfoMessage -= handler;
-                                conn.Close();
+                                conn?.Close();
                             }
 
                             var finished = i == _iterations - 1;

--- a/src/SQLQueryStress/Program.cs
+++ b/src/SQLQueryStress/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
+using System.Collections.Generic;
 
 namespace SQLQueryStress
 {
@@ -17,10 +18,86 @@ namespace SQLQueryStress
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            var f = args.Length > 0 ? new Form1(args[0]) : new Form1();
+            Dictionary<string, string> arguments = GetCommandLineArguments(args);
 
+            string configFileName;
+            bool unattendedMode;
+            int numThreads;
+
+            configFileName = arguments["C"];
+            try { unattendedMode = Convert.ToBoolean(arguments["U"]); } catch { unattendedMode = false; }
+            try { numThreads = Convert.ToInt32(arguments["T"]); } catch { numThreads = 0; }
+
+            var f = new Form1(configFileName, unattendedMode, numThreads);
             f.StartPosition = FormStartPosition.CenterScreen;
             Application.Run(f);
+        }
+
+        private static Dictionary<string, string> GetCommandLineArguments (string[] args)
+        {
+            /* allow commind line aguments, named or position based
+             * > SQLQueryStress.exe "fast.sqlstress" true 75
+             * > SQLQueryStress.exe -C "fast.sqlstress" -U true -T 75
+             * > SQLQueryStress.exe -C "fast.sqlstress" -U -T 75
+            */
+            string[] ParamOrder = { "C", "U", "T" };
+            string key, value = "";
+            bool isFlag = false;
+            Dictionary<string, string> arguments = new Dictionary<string, string>();
+            // set default values
+            arguments["C"] = "";        // config file
+            arguments["U"] = "false";   // run in unattended mode
+            arguments["T"] = "0";       // number of threads - overrides value in config file
+
+            if (args.Length > 0)
+            {
+                // see if using named arguments
+                if (args[0].Length > 0 && (args[0].Substring(0, 1) == "-" || args[0].Substring(0, 1) == "/"))
+                {
+                    // using name based
+                    for (int i = 0; i < args.Length; i++)
+                    {
+                        if (args[i].Substring(0, 1) == "-" || args[i].Substring(0, 1) == "/")
+                        {
+                            key = args[i].Substring(1).ToUpper();
+                            value = "";
+                            isFlag = true;
+
+                            // peak at next argument to see if value or another key
+                            if (i + 1 < args.Length)
+                            {
+                                value = args[i + 1];
+                                isFlag = false;
+                                if (value.Substring(0, 1) == "-" || value.Substring(0, 1) == "/")
+                                    // it could be another key, if it's valid, and the current key can be a flag
+                                    if (ParamOrder.Contains(value.Substring(1)) && key == "U")
+                                        isFlag = true;
+                            }
+                                
+                            if (isFlag)
+                            {
+                                // for valid flag parameters we apply true value
+                                if (key == "U") value = "true";
+                            }
+                            // since it's not a flag, skip the next argument as we got the value from it
+                            else i++;    
+
+                            // if we got a valid key, add to our arguments
+                            if (ParamOrder.Contains(key)) arguments[key] = value;
+                        }
+                    }
+                }
+                else
+                {
+                    // using position based, so assign in order
+                    for (int i = 0; (i < args.Length && i < ParamOrder.Length); i++)
+                        arguments[ParamOrder[i]] = args[i];
+
+                }
+
+            }
+
+            return arguments;
         }
 
         private static Assembly OnResolveAssembly(object sender, ResolveEventArgs args)

--- a/src/SQLQueryStress/Program.cs
+++ b/src/SQLQueryStress/Program.cs
@@ -17,8 +17,8 @@ namespace SQLQueryStress
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            bool autoStart = (args.Length > 1) ? Convert.ToBoolean(args[1]) : false;
-            var f = args.Length > 0 ? new Form1(args[0], autoStart) : new Form1();
+            var f = args.Length > 0 ? new Form1(args[0]) : new Form1();
+
             f.StartPosition = FormStartPosition.CenterScreen;
             Application.Run(f);
         }

--- a/src/SQLQueryStress/SqlControl.xaml.cs
+++ b/src/SQLQueryStress/SqlControl.xaml.cs
@@ -38,7 +38,7 @@ namespace SQLQueryStress
             }
             finally
             {
-                if (stream != null) stream.Dispose();
+                stream?.Dispose();
             }
         }
     }


### PR DESCRIPTION
reverted the "?" changes.
changed the variable/argument to unattended mode for clarity.
added ability to specify named or position based parameters as follows:
/C "config file name"
/U
/T 50
where /U means unattended mode - application will start, load the config file, override the number of threads (if needed) execute until completion and then exit.
/T 50 means override the number of threads specified in the config file with 50.
examples:
SQLQueryStress.exe "fast.sqlstress" true 75
SQLQueryStress.exe -C "fast.sqlstress" -U true -T 75
SQLQueryStress.exe -C "fast.sqlstress" -U -T 75

**TO DO: the command line argument parsing should be changed to a parsing library**